### PR TITLE
Avoid using .asPathName method

### DIFF
--- a/Classes/SphericalDesign.sc
+++ b/Classes/SphericalDesign.sc
@@ -265,7 +265,8 @@ TDesignLib {
 	classvar <defaultPath;
 
 	*initClass {
-		defaultPath = PathName(thisMethod.filenameSymbol.asString).parentPath.asPathName.parentPath.absolutePath +/+ "Designs/t-designs/sloane/";
+		defaultPath = PathName(this.filenameSymbol.asString).parentPath;
+		defaultPath = PathName(defaultPath).parentPath +/+ "Designs/t-designs/sloane/";
 	}
 
 	*initLib {


### PR DESCRIPTION
Previous implementation of initClass inits defaultPath using .asPathName method.
This adds a dependancy for the class library that defines this convenience method, but this class library dependancy is not described anywhere I can see.

This version is a simplification that makes it more readable and avoids this dependancy.